### PR TITLE
fix: tolerate failure to install browsers

### DIFF
--- a/bin/test-browser-example.js
+++ b/bin/test-browser-example.js
@@ -3,6 +3,16 @@
 
 import { execa } from 'execa'
 
+try {
+  // install deps
+  await execa('npx', ['-y', 'playwright', 'install', '--with-deps'], {
+    stdio: 'inherit'
+  })
+} catch (err) {
+  if (!err.message.includes('Could not get lock')) {
+    throw err
+  }
+}
 for (const file of process.argv.slice(2)) {
   // run test
   await execa('npx', ['playwright', 'test', file], {

--- a/bin/test-browser-example.js
+++ b/bin/test-browser-example.js
@@ -13,6 +13,7 @@ try {
     throw err
   }
 }
+
 for (const file of process.argv.slice(2)) {
   // run test
   await execa('npx', ['playwright', 'test', file], {

--- a/bin/test-browser-example.js
+++ b/bin/test-browser-example.js
@@ -3,11 +3,6 @@
 
 import { execa } from 'execa'
 
-// install deps
-await execa('npx', ['-y', 'playwright', 'install', '--with-deps'], {
-  stdio: 'inherit'
-})
-
 for (const file of process.argv.slice(2)) {
   // run test
   await execa('npx', ['playwright', 'test', file], {


### PR DESCRIPTION
This is done elsewhere in test jobs and can cause problems when run in parallel in monorepos